### PR TITLE
Meds eval schema compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ generate-subsets = "MEDS_tabular_automl.scripts.generate_subsets:main"
 
 [project.optional-dependencies]
 dev = ["pre-commit<4"]
-tests = ["pytest", "pytest-cov", "rootutils"]
+tests = ["pytest", "pytest-cov[toml]", "rootutils"]
 profiling = ["mprofile", "matplotlib"]
 autogluon = ["autogluon; python_version=='3.11.*'"]  # Environment marker to restrict AutoGluon to Python 3.11
 docs = [
@@ -50,6 +50,14 @@ docs = [
     "mkdocs-snippets==1.3.0",
     "mkdocstrings==0.25.2",
     "mkdocstrings-python==1.10.8"
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: nocover",
+    "raise NotImplementedError",
+    "raise NotImplementedError()",
+    "if __name__ == .__main__.:",
 ]
 
 [build-system]

--- a/src/MEDS_tabular_automl/configs/launch_model.yaml
+++ b/src/MEDS_tabular_automl/configs/launch_model.yaml
@@ -22,6 +22,10 @@ delete_below_top_k: -1
 
 name: launch_model
 
+prediction_splits:
+  - held_out
+  - tuning
+
 hydra:
   sweep:
     dir: ${time_output_model_dir}/hydra/

--- a/src/MEDS_tabular_automl/evaluation_callback.py
+++ b/src/MEDS_tabular_automl/evaluation_callback.py
@@ -65,8 +65,8 @@ class EvaluationCallback(Callback):
             ...         'sweep_results_dir': str(sweep_results_dir),
             ...         'performance_log_stem': 'performance',
             ...         'best_trial_dir': str(Path(temp_dir) / 'best_trial'),
-            ...         'time_output_model_dir': str(Path(temp_dir) / 'output')
             ...     },
+            ...     'time_output_model_dir': str(Path(temp_dir) / 'output'),
             ...     'prediction_splits': ['test'],
             ...     'delete_below_top_k': 1
             ... })
@@ -75,7 +75,7 @@ class EvaluationCallback(Callback):
             >>> cb = EvaluationCallback()
             >>>
             >>> # Run the method
-            >>> Path(config.path.time_output_model_dir).mkdir()
+            >>> Path(config.time_output_model_dir).mkdir()
             >>> result = cb.on_multirun_end(config)
             >>>
             >>> # Verify results
@@ -107,7 +107,7 @@ class EvaluationCallback(Callback):
         best_trial_dir = Path(config.path.sweep_results_dir) / performance["trial_name"].cast(pl.String)[0]
         output_best_trial_dir = Path(config.path.best_trial_dir)
         shutil.copytree(best_trial_dir, output_best_trial_dir)
-        performance.write_parquet(Path(config.path.time_output_model_dir) / "sweep_results_summary.parquet")
+        performance.write_parquet(Path(config.time_output_model_dir) / "sweep_results_summary.parquet")
 
         self.store_predictions(output_best_trial_dir, config.prediction_splits)
 

--- a/src/MEDS_tabular_automl/evaluation_callback.py
+++ b/src/MEDS_tabular_automl/evaluation_callback.py
@@ -8,9 +8,83 @@ from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
 
+class MockModelLauncher:  # pragma: no cover
+    def load_model(self, model_path):
+        pass
+
+    def _build(self):
+        pass
+
+    def predict(self, split):
+        return pl.DataFrame({"predictions": [0.1, 0.2]})
+
+
 class EvaluationCallback(Callback):
     def on_multirun_end(self, config: DictConfig, **kwargs):
-        """Find best model based on log files and logger.info its performance and hyperparameters."""
+        """Find best model based on log files and logger.info its performance and hyperparameters.
+
+        Args:
+            config (DictConfig): Configuration dictionary containing paths and settings
+            **kwargs: Additional keyword arguments
+
+        Returns:
+            polars.DataFrame: Performance of the top model
+
+        Raises:
+            FileNotFoundError: If log files are incomplete or not found
+
+        Example:
+            >>> import tempfile
+            >>> import polars as pl
+            >>> from pathlib import Path
+            >>> from omegaconf import OmegaConf
+            >>>
+            >>> # Create a temporary directory for testing
+            >>> temp_dir = tempfile.mkdtemp()
+            >>> # Setup mock sweep results directory
+            >>> sweep_results_dir = Path(temp_dir) / 'sweep_results'
+            >>> sweep_results_dir.mkdir()
+            >>>
+            >>> # Create mock trial directories
+            >>> trial_names = ['trial1', 'trial2']
+            >>> for trial in trial_names:
+            ...     trial_path = sweep_results_dir / trial
+            ...     trial_path.mkdir()
+            ...
+            ...     # Create mock performance log
+            ...     performance_log = pl.DataFrame({
+            ...         'trial_name': [trial],
+            ...         'tuning_auc': [0.9 if trial == 'trial1' else 0.8],
+            ...         'test_auc': [0.85 if trial == 'trial1' else 0.75]
+            ...     })
+            ...     performance_log.write_csv(trial_path / 'performance.log')
+            >>>
+            >>> # Create configuration
+            >>> config = OmegaConf.create({
+            ...     'path': {
+            ...         'sweep_results_dir': str(sweep_results_dir),
+            ...         'performance_log_stem': 'performance',
+            ...         'best_trial_dir': str(Path(temp_dir) / 'best_trial'),
+            ...         'time_output_model_dir': str(Path(temp_dir) / 'output')
+            ...     },
+            ...     'prediction_splits': ['test'],
+            ...     'delete_below_top_k': 1
+            ... })
+            >>>
+            >>> # Create a mock evaluation callback
+            >>> cb = EvaluationCallback()
+            >>>
+            >>> # Run the method
+            >>> Path(config.path.time_output_model_dir).mkdir()
+            >>> result = cb.on_multirun_end(config)
+            >>>
+            >>> # Verify results
+            >>> result['trial_name'][0] == 'trial1'
+            True
+            >>> # Clean up the temporary directory
+            >>> import shutil
+            >>> shutil.rmtree(temp_dir)
+        """
         log_fp = Path(config.path.sweep_results_dir)
 
         try:
@@ -33,13 +107,45 @@ class EvaluationCallback(Callback):
         best_trial_dir = Path(config.path.sweep_results_dir) / performance["trial_name"].cast(pl.String)[0]
         output_best_trial_dir = Path(config.path.best_trial_dir)
         shutil.copytree(best_trial_dir, output_best_trial_dir)
-        performance.write_parquet(Path(config.time_output_model_dir) / "sweep_results_summary.parquet")
+        performance.write_parquet(Path(config.path.time_output_model_dir) / "sweep_results_summary.parquet")
 
         self.store_predictions(output_best_trial_dir, config.prediction_splits)
 
         return performance.head(1)
 
     def store_predictions(self, best_trial_dir, splits):
+        """Store predictions for specified data splits from the best model.
+
+        Args:
+            best_trial_dir (Path): Directory of the best trial
+            splits (List[str]): Data splits to generate predictions for
+
+        Example:
+        >>> import tempfile
+        >>> import polars as pl
+        >>> from pathlib import Path
+        >>> from unittest.mock import Mock, patch
+        >>> import shutil
+        >>>
+        >>> temp_dir = tempfile.mkdtemp()
+        >>> best_trial_dir = Path(temp_dir)
+        >>>
+        >>> # Create mock config and xgboost files
+        >>> _ = (best_trial_dir / 'config.log').write_text('''
+        ... model_launcher:
+        ...   _target_: MEDS_tabular_automl.evaluation_callback.MockModelLauncher
+        ... ''')
+        >>> (best_trial_dir / 'xgboost.json').touch()
+        >>>
+        >>> # Mock model launcher
+        >>>
+        >>> cb = EvaluationCallback()
+        >>> cb.store_predictions(best_trial_dir, ['test'])
+        >>> # Verify predictions file was created
+        >>> (best_trial_dir / 'test_predictions.parquet').exists()
+        True
+        >>> shutil.rmtree(temp_dir)
+        """
         config = Path(best_trial_dir) / "config.log"
         xgboost_fp = Path(best_trial_dir) / "xgboost.json"
         if not xgboost_fp.exists():
@@ -56,7 +162,27 @@ class EvaluationCallback(Callback):
             pred_df.write_parquet(Path(best_trial_dir) / f"{split}_predictions.parquet")
 
     def log_performance(self, best_model_performance):
-        """logger.info performance of the best model with nice formatting."""
+        """Log performance details of the best model.
+
+        Args:
+            best_model_performance (polars.DataFrame): Performance data of the best model
+
+        Example:
+            >>> import polars as pl
+            >>>
+            >>> # Create a mock performance DataFrame
+            >>> best_model_performance = pl.DataFrame({
+            ...     'trial_name': ['trial1'],
+            ...     'tuning_auc': [0.85],
+            ...     'test_auc': [0.82]
+            ... })
+            >>>
+            >>> # Create an instance of the evaluation callback
+            >>> cb = EvaluationCallback()
+            >>>
+            >>> # Test the method (this will log to console)
+            >>> cb.log_performance(best_model_performance)  # Doctest: +ELLIPSIS
+        """
         best_model = best_model_performance["trial_name"][0]
         tuning_auc = best_model_performance["tuning_auc"][0]
         test_auc = best_model_performance["test_auc"][0]

--- a/src/MEDS_tabular_automl/evaluation_callback.py
+++ b/src/MEDS_tabular_automl/evaluation_callback.py
@@ -3,10 +3,9 @@ from pathlib import Path
 
 import polars as pl
 from hydra.experimental.callback import Callback
+from hydra.utils import instantiate
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
-from hydra.utils import instantiate
-import xgboost as xgb
 
 
 class EvaluationCallback(Callback):

--- a/src/MEDS_tabular_automl/evaluation_callback.py
+++ b/src/MEDS_tabular_automl/evaluation_callback.py
@@ -42,6 +42,10 @@ class EvaluationCallback(Callback):
     def store_predictions(self, best_trial_dir, splits):
         config = Path(best_trial_dir) / "config.log"
         xgboost_fp = Path(best_trial_dir) / "xgboost.json"
+        if not xgboost_fp.exists():
+            logger.warning("Prediction parquets not stored, we only support storing them for xgboost models.")
+            return
+
         cfg = OmegaConf.load(config)
         model_launcher = instantiate(cfg.model_launcher)
         model_launcher.load_model(xgboost_fp)

--- a/src/MEDS_tabular_automl/xgboost_model.py
+++ b/src/MEDS_tabular_automl/xgboost_model.py
@@ -6,6 +6,8 @@ import xgboost as xgb
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 from sklearn.metrics import roc_auc_score
+import polars as pl
+import numpy as np
 
 from .base_model import BaseModel
 from .tabular_dataset import TabularDataset
@@ -124,6 +126,51 @@ class XGBoostModel(BaseModel):
         else:
             self._build_iterators()
             self._build_dmatrix_from_iterators()
+    
+    def load_model(self, xgboost_json_fp: Path):
+        self.model = xgb.Booster()
+        self.model.load_model(str(xgboost_json_fp))
+    
+    def _predict(self, split="held_out") -> tuple[np.ndarray, np.ndarray]:
+        """Helper Function that retrieves model predictions and labels."""
+        if split == "tuning":
+            y_pred = self.model.predict(self.dtuning)
+            y_true = self.dtuning.get_label()
+        elif split == "held_out":
+            y_pred = self.model.predict(self.dheld_out)
+            y_true = self.dheld_out.get_label()
+        elif split == "train":
+            y_pred = self.model.predict(self.dtrain)
+            y_true = self.dtrain.get_label()
+        else:
+            raise ValueError(f"Invalid split for evaluation: {split}")
+        return y_true, y_pred
+    
+    def predict(self, split="held_out") -> pl.DataFrame:
+        """Retrieves logits for the given split.
+
+        Returns:
+            The evaluation metric as the ROC AUC score.
+        """
+        y_true, y_pred = self._predict(split)
+
+        if split == "tuning":
+            xgb_iterator = self.ituning
+        elif split == "held_out":
+            xgb_iterator = self.iheld_out
+        elif split == "train":
+            xgb_iterator = self.itrain
+        else:
+            raise ValueError(f"Invalid split for evaluation: {split}")
+        _, cached_labels = xgb_iterator._load_ids_and_labels(load_ids=False, load_labels=True)
+        parquet_files = list(Path(self.cfg.path.input_label_cache_dir) / split / f"{key}.parquet"  for key in cached_labels.keys())
+        labels = pl.concat([pl.read_parquet(fp) for fp in parquet_files])
+        predictions_df = pl.DataFrame({"subject_id": labels['subject_id'], "prediction_time": labels['time'], "boolean_value": y_true, "predicted_boolean_value": y_pred.round(), "predicted_boolean_probability": y_pred, "event_id": labels['event_id']})
+        if not (predictions_df['boolean_value'] == labels['label']).all():
+            mismatched_labels = predictions_df['boolean_value'] == labels['label'] 
+            raise ValueError(f"Label mismatch: {sum(mismatched_labels)} incorrect predictions")
+
+        return predictions_df
 
     def _train(self):
         """Trains the model."""
@@ -168,17 +215,7 @@ class XGBoostModel(BaseModel):
         Returns:
             The evaluation metric as the ROC AUC score.
         """
-        if split == "tuning":
-            y_pred = self.model.predict(self.dtuning)
-            y_true = self.dtuning.get_label()
-        elif split == "held_out":
-            y_pred = self.model.predict(self.dheld_out)
-            y_true = self.dheld_out.get_label()
-        elif split == "train":
-            y_pred = self.model.predict(self.dtrain)
-            y_true = self.dtrain.get_label()
-        else:
-            raise ValueError(f"Invalid split for evaluation: {split}")
+        y_true, y_pred = self._predict(split)
         return roc_auc_score(y_true, y_pred)
 
     def save_model(self, output_fp: Path):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -344,7 +344,6 @@ def test_integration(tmp_path):
         else:
             assert len(glob.glob(str(output_model_dir / "*/sweep_results/**/*.pkl"))) == 2
             assert len(glob.glob(str(output_model_dir / "*/best_trial/*.pkl"))) == 1
-        breakpoint()
         time_output_dir = next(output_model_dir.iterdir())
         time_output_dir = [each for each in output_model_dir.iterdir()][0]
         assert (time_output_dir / "best_trial/held_out_predictions.parquet").exists()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -344,4 +344,11 @@ def test_integration(tmp_path):
         else:
             assert len(glob.glob(str(output_model_dir / "*/sweep_results/**/*.pkl"))) == 2
             assert len(glob.glob(str(output_model_dir / "*/best_trial/*.pkl"))) == 1
+        breakpoint()
+        time_output_dir = next(output_model_dir.iterdir())
+        time_output_dir = [each for each in output_model_dir.iterdir()][0]
+        assert (time_output_dir / "best_trial/held_out_predictions.parquet").exists()
+        assert (time_output_dir / "best_trial/tuning_predictions.parquet").exists()
+        assert (time_output_dir / "sweep_results_summary.parquet").exists()
+
         shutil.rmtree(output_model_dir)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -308,6 +308,11 @@ def test_integration(tmp_path):
         if model == "xgboost":
             assert len(glob.glob(str(output_model_dir / "*/sweep_results/**/*.json"))) == 2
             assert len(glob.glob(str(output_model_dir / "*/best_trial/*.json"))) == 1
+
+            time_output_dir = next(output_model_dir.iterdir())
+            assert (time_output_dir / "best_trial/held_out_predictions.parquet").exists()
+            assert (time_output_dir / "best_trial/tuning_predictions.parquet").exists()
+            assert (time_output_dir / "sweep_results_summary.parquet").exists()
         else:
             assert len(glob.glob(str(output_model_dir / "*/sweep_results/**/*.pkl"))) == 2
             assert len(glob.glob(str(output_model_dir / "*/best_trial/*.pkl"))) == 1
@@ -341,13 +346,13 @@ def test_integration(tmp_path):
         if model == "xgboost":
             assert len(glob.glob(str(output_model_dir / "*/sweep_results/**/*.json"))) == 2
             assert len(glob.glob(str(output_model_dir / "*/best_trial/*.json"))) == 1
+
+            time_output_dir = next(output_model_dir.iterdir())
+            assert (time_output_dir / "best_trial/held_out_predictions.parquet").exists()
+            assert (time_output_dir / "best_trial/tuning_predictions.parquet").exists()
+            assert (time_output_dir / "sweep_results_summary.parquet").exists()
         else:
             assert len(glob.glob(str(output_model_dir / "*/sweep_results/**/*.pkl"))) == 2
             assert len(glob.glob(str(output_model_dir / "*/best_trial/*.pkl"))) == 1
-        time_output_dir = next(output_model_dir.iterdir())
-        time_output_dir = [each for each in output_model_dir.iterdir()][0]
-        assert (time_output_dir / "best_trial/held_out_predictions.parquet").exists()
-        assert (time_output_dir / "best_trial/tuning_predictions.parquet").exists()
-        assert (time_output_dir / "sweep_results_summary.parquet").exists()
 
         shutil.rmtree(output_model_dir)


### PR DESCRIPTION
Only for xgboost atm.

This adds a callback after a multirun xgboost hparam sweep.
It stores all model predictions in the [meds-eval schema](https://github.com/kamilest/meds-evaluation/tree/main?tab=readme-ov-file#prediction-schema).