### PR TITLE
Allow labels prior to any measurements for the patient during tabularization

### DIFF
--- a/src/MEDS_tabular_automl/generate_summarized_reps.py
+++ b/src/MEDS_tabular_automl/generate_summarized_reps.py
@@ -155,27 +155,25 @@ def aggregate_matrix(
 
         >>> windows = pl.DataFrame({"min_index": [0], "max_index": [0]})
         >>> aggregate_matrix(windows, matrix, 'sum', num_features).toarray()
-        array([[0, 0, 0]])
+        array([[0., 0., 0.]])
         >>> aggregate_matrix(windows, matrix, 'min', num_features).toarray()
-        array([[0, 0, 0]])
+        array([[0., 0., 0.]])
         >>> aggregate_matrix(windows, matrix, 'max', num_features).toarray()
-        array([[0, 0, 0]])
+        array([[0., 0., 0.]])
         >>> aggregate_matrix(windows, matrix, 'sum_sqd', num_features).toarray()
-        array([[0, 0, 0]])
+        array([[0., 0., 0.]])
         >>> aggregate_matrix(windows, matrix, 'count', num_features).toarray()
-        array([[0, 0, 0]])
+        array([[0., 0., 0.]])
     """
     tqdm = load_tqdm(use_tqdm)
     agg = agg.split("/")[-1]
     matrix = csr_array(matrix)
-    # if agg.startswith("sum"):
-    #     out_dtype = np.float32
-    # else:
-    #     out_dtype = np.int32
     data, row, col = [], [], []
     for i, window in tqdm(enumerate(windows.iter_rows(named=True)), total=len(windows)):
         min_index = window["min_index"]
         max_index = window["max_index"]
+        if min_index == max_index:
+            continue
         subset_matrix = matrix[min_index:max_index, :]
         agg_matrix = sparse_aggregate(subset_matrix, agg)
         if isinstance(agg_matrix, np.ndarray):

--- a/src/MEDS_tabular_automl/generate_summarized_reps.py
+++ b/src/MEDS_tabular_automl/generate_summarized_reps.py
@@ -152,6 +152,18 @@ def aggregate_matrix(
         array([[3, 1, 0],
                [6, 1, 1],
                [5, 0, 1]])
+
+        >>> windows = pl.DataFrame({"min_index": [0], "max_index": [0]})
+        >>> aggregate_matrix(windows, matrix, 'sum', num_features).toarray()
+        array([[0, 0, 0]])
+        >>> aggregate_matrix(windows, matrix, 'min', num_features).toarray()
+        array([[0, 0, 0]])
+        >>> aggregate_matrix(windows, matrix, 'max', num_features).toarray()
+        array([[0, 0, 0]])
+        >>> aggregate_matrix(windows, matrix, 'sum_sqd', num_features).toarray()
+        array([[0, 0, 0]])
+        >>> aggregate_matrix(windows, matrix, 'count', num_features).toarray()
+        array([[0, 0, 0]])
     """
     tqdm = load_tqdm(use_tqdm)
     agg = agg.split("/")[-1]

--- a/src/MEDS_tabular_automl/generate_summarized_reps.py
+++ b/src/MEDS_tabular_automl/generate_summarized_reps.py
@@ -83,6 +83,44 @@ def aggregate_matrix(
 
     Raises:
         TypeError: If the type of the aggregated matrix is not compatible for further operations.
+
+    Example:
+        >>> windows = pl.DataFrame({"min_index": [0, 0, 1], "max_index": [1, 2, 2]})
+        >>> matrix = coo_array(([1, 2, 3, 1, 1], ([0, 1, 2, 0, 2], [0, 0, 0, 1, 2])), shape=(3, 3))
+        >>> matrix.toarray()
+        array([[1, 1, 0],
+               [2, 0, 0],
+               [3, 0, 1]])
+        >>> agg = "sum"
+        >>> num_features = 3
+        >>> aggregated_matrix = aggregate_matrix(windows, matrix, agg, num_features)
+        >>> aggregated_matrix.toarray()
+        array([[3, 1, 0],
+               [6, 1, 1],
+               [5, 0, 1]])
+
+        Maybe nans are causing this:
+        >>> data = np.array([1.0, 2.0, 3.0, 1.0, np.nan])
+        >>> matrix = coo_array((data, ([0, 1, 2, 0, 2], [0, 0, 0, 1, 2])), shape=(3, 3))
+        >>> aggregated_matrix = aggregate_matrix(windows, matrix, agg, num_features)
+        >>> windows = pl.DataFrame({"min_index": [0, 0, 1], "max_index": [1, 2, 2]})
+
+        Maybe no windows is causing this:
+        >>> windows = pl.DataFrame({"min_index": [], "max_index": []},
+        ...                         schema={"min_index": pl.Int32, "max_index": pl.Int32})
+        >>> matrix = coo_array(([1, 2, 3, 1, 1], ([0, 1, 2, 0, 2], [0, 0, 0, 1, 2])), shape=(3, 3))
+        >>> aggregated_matrix = aggregate_matrix(windows, matrix, agg, num_features)
+
+        Maybe an empty window causes this:
+        >>> windows = pl.DataFrame({"min_index": [0], "max_index": [0]})
+        >>> matrix = coo_array(([1, 2, 3, 1, 1], ([0, 1, 2, 0, 2], [0, 0, 0, 1, 2])), shape=(3, 3))
+        >>> aggregated_matrix = aggregate_matrix(windows, matrix, agg, num_features)
+
+        Maybe a null window causes this:
+        >>> windows = pl.DataFrame({"min_index": [0], "max_index": [None]},
+        ...                         schema={"min_index": pl.Int32, "max_index": pl.Int32})
+        >>> matrix = coo_array(([1, 2, 3, 1, 1], ([0, 1, 2, 0, 2], [0, 0, 0, 1, 2])), shape=(3, 3))
+        >>> aggregated_matrix = aggregate_matrix(windows, matrix, agg, num_features)
     """
     tqdm = load_tqdm(use_tqdm)
     agg = agg.split("/")[-1]


### PR DESCRIPTION
Task-based workflow fails when label_df has a label prior to any meds data for the patient.

This pull request fixes this.

We add doctests to `get_rolling_window_indicies` and `aggregate_matrix` and when window indices are null (i.e. a label is prior to any observation), we set the rolling window indices to (0,0) so aggregations will be over an empty slice.