### PR TITLE
Fix typos in docs and comments

### DIFF
--- a/MIMICIV_TUTORIAL/README.MD
+++ b/MIMICIV_TUTORIAL/README.MD
@@ -110,7 +110,7 @@ We recommend using this script, as opposed to the task specific script, when tab
 
 ```console
 export N_PARALLEL_WORKERS=48 # Set number of workers
-export RESHARD_DIR=${ROOT_DIR}/reshareded_meds/ # set to directory to output reshareded meds data
+export RESHARD_DIR=${ROOT_DIR}/resharded_meds/ # set to directory to output resharded meds data
 TASKS_STR=$(echo ${TASKS[@]} | tr ' ' ',')
 bash MIMICIV_TUTORIAL/tabularize_meds.sh "${MIMICIV_MEDS_DIR}" "$RESHARD_DIR" $OUTPUT_TABULARIZATION_DIR \
     "${TASKS_STR}" $TASKS_DIR $OUTPUT_MODEL_DIR $N_PARALLEL_WORKERS \

--- a/MIMICIV_TUTORIAL/tasks/mortality/README.md
+++ b/MIMICIV_TUTORIAL/tasks/mortality/README.md
@@ -1,7 +1,7 @@
 # Mortality Prediction
 
 This folder contains tasks for predicting mortality in patients in a variety of clinical contexts. Mortality
-is a common prediciton target because
+is a common prediction target because
 
 1. The "death" label is unambiguous, clearly important, and (often) easy to collect.
 2. Mortality is a common outcome in clinical research, and many studies have collected data that can be used

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This is a common misconception. _Tabular_ data refers to data that can be organi
 set of rows/columns such that the entirety of a "sample" or "instance" for modeling or analysis is contained
 in a single row, and the set of columns possibly observed (there can be missingness) is consistent across all
 rows. Structured EHR data does not satisfy this definition, as we will have different numbers of observations
-of medical codes and values at different timestamps for different patients, so it cannot simultanesouly
+of medical codes and values at different timestamps for different patients, so it cannot simultaneously
 satisfy the (1) "single row single instance", (2) "consistent set of columns", and (3) "logical" requirements.
 Thus, in this pipeline, when we say we will produce a "tabular" view of MEDS data, we mean a dataset that can
 realize these constraints, which will explicitly involve summarizing the patient data over various historical

--- a/src/MEDS_tabular_automl/generate_summarized_reps.py
+++ b/src/MEDS_tabular_automl/generate_summarized_reps.py
@@ -261,7 +261,7 @@ def compute_agg(
 
     Dataframe is expected to only have the relevant columns for aggregating. It should have the subject_id and
     time columns, and then only code columns if agg is a code aggregation or only value columns if it is
-    a value aggreagation.
+    a value aggregation.
 
     Args:
         index_df: The DataFrame with 'subject_id' and 'time' columns used for grouping.

--- a/src/MEDS_tabular_automl/tabular_dataset.py
+++ b/src/MEDS_tabular_automl/tabular_dataset.py
@@ -322,7 +322,7 @@ class TabularDataset(TimeableMixin):
         Raises:
             ValueError: If any of the required files for the shard do not exist.
         """
-        # get all window_size x aggreagation files using the file resolver
+        # get all window_size x aggregation files using the file resolver
         files = get_model_files(self.cfg, self.split, self._data_shards[idx])
 
         if not all(file.exists() for file in files):


### PR DESCRIPTION
## Summary
- fix minor typos in README files
- fix comment typos in the code

## Testing
- `pytest -k "not slow" -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d386dbf4832c85af2313cacde641