### PR TITLE
Relax dependency version constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "polars~=1.26.0",
+  "polars>=1.26.0",
   "pyarrow",
-  "hydra-core==1.3.2",
+  "hydra-core>=1.3.2,<2",
   "numpy",
   "scipy<1.14.0",
   "pandas",
@@ -31,9 +31,9 @@ dependencies = [
   "hydra-optuna-sweeper",
   "hydra-joblib-launcher",
   "ml-mixins",
-  "meds~=0.4.0",
-  "meds-transforms~=0.5.0",
-  "meds-evaluation",
+  "meds>=0.4.0",
+  "meds-transforms>=0.5.0",
+  "meds-evaluation==0.0.3",
 ]
 
 [tool.setuptools_scm]

--- a/uv.lock
+++ b/uv.lock
@@ -2821,13 +2821,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "autogluon", marker = "python_full_version == '3.11.*' and extra == 'autogluon'" },
-    { name = "hydra-core", specifier = "==1.3.2" },
+    { name = "hydra-core", specifier = ">=1.3.2,<2" },
     { name = "hydra-joblib-launcher" },
     { name = "hydra-optuna-sweeper" },
     { name = "matplotlib", marker = "extra == 'profiling'" },
-    { name = "meds", specifier = "~=0.4.0" },
-    { name = "meds-evaluation" },
-    { name = "meds-transforms", specifier = "~=0.5.0" },
+    { name = "meds", specifier = ">=0.4.0" },
+    { name = "meds-evaluation", specifier = "==0.0.3" },
+    { name = "meds-transforms", specifier = ">=0.5.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.0" },
     { name = "mkdocs-gen-files", marker = "extra == 'docs'", specifier = "==0.5.0" },
     { name = "mkdocs-get-deps", marker = "extra == 'docs'", specifier = "==0.2.0" },
@@ -2844,7 +2844,7 @@ requires-dist = [
     { name = "mprofile", marker = "extra == 'profiling'" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "polars", specifier = "~=1.26.0" },
+    { name = "polars", specifier = ">=1.26.0" },
     { name = "pyarrow" },
     { name = "scikit-learn" },
     { name = "scipy", specifier = "<1.14.0" },
@@ -4230,16 +4230,16 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.26.0"
+version = "1.27.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/c2/56a750b82e74c5af7b821215eab3ee992d9ef11310dad353f5b2086ef7db/polars-1.26.0.tar.gz", hash = "sha256:b5492d38e5ec2ae6a8853833c5a31549194a361b901134fc5f2f57b49bd563ea", size = 4522991, upload-time = "2025-03-23T11:53:37.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/96/56ab877d3d690bd8e67f5c6aabfd3aa8bc7c33ee901767905f564a6ade36/polars-1.27.1.tar.gz", hash = "sha256:94fcb0216b56cd0594aa777db1760a41ad0dfffed90d2ca446cf9294d2e97f02", size = 4555382, upload-time = "2025-04-11T10:26:24.708Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/99/ce4427576a6134504e6dd58f5d411d55b228a05950c5fff5b75e90263cb1/polars-1.26.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2afefcd356608981b2e15d46df9ddaa6e77f36095ebeb73c3261e198bd51c925", size = 34767938, upload-time = "2025-03-23T11:52:27.477Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/0a/5c9455ff271c3583bf0fd505911e5787ca7bc0f247968853cb6dcfbedffb/polars-1.26.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:587eb3c5000423eb20be998f523e605ddba0d3c598ba4a7e2a4d0b92b1fd2a7e", size = 31612374, upload-time = "2025-03-23T11:52:32.896Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/0a/c9e388b35533fc1827eaeb0f3940ba0a1058511bf77aaa689ebb1b0bef88/polars-1.26.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66c30f4b7e060c2e7f3a45d6ac94ab3b179831a2f1e629401bf7912d54311529", size = 35404704, upload-time = "2025-03-23T11:52:36.764Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/eb/b420131563a42ac0866224aa6284a356107d036c32d825c5478767a1446e/polars-1.26.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:110d6987d37ae954a5ef16d739fb717df9d39b144790d12d98fb3e72ed35621c", size = 32569800, upload-time = "2025-03-23T11:52:40.68Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/8d/b28ae5d63a4bafdfe81d132efc6b8d076ef2c866ecbf5d24ca3b1f53b88b/polars-1.26.0-cp39-abi3-win_amd64.whl", hash = "sha256:189a58aaf393003515fa6d83e2dea815a2b448265f2007a926274ed12672583c", size = 35617074, upload-time = "2025-03-23T11:52:44.279Z" },
-    { url = "https://files.pythonhosted.org/packages/af/21/7a76c58203f0806cb5b1155e4994693e618d4de5ca6a34388ae85267ccc4/polars-1.26.0-cp39-abi3-win_arm64.whl", hash = "sha256:58db2dce39cad5f8fc8e8c5c923a250eb21eff4146b03514d570d1c205a4874c", size = 31895936, upload-time = "2025-03-23T11:52:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/be965ca4e1372805d0d2313bb4ed8eae88804fc3bfeb6cb0a07c53191bdb/polars-1.27.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ba7ad4f8046d00dd97c1369e46a4b7e00ffcff5d38c0f847ee4b9b1bb182fb18", size = 34756840, upload-time = "2025-04-11T10:25:19.734Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1a/ae019d323e83c6e8a9b4323f3fea94e047715847dfa4c4cbaf20a6f8444e/polars-1.27.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:339e3948748ad6fa7a42e613c3fb165b497ed797e93fce1aa2cddf00fbc16cac", size = 31616000, upload-time = "2025-04-11T10:25:24.867Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c1/c65924c0ca186f481c02b531f1ec66c34f9bbecc11d70246562bb4949876/polars-1.27.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f801e0d9da198eb97cfb4e8af4242b8396878ff67b655c71570b7e333102b72b", size = 35388976, upload-time = "2025-04-11T10:25:28.426Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c2/37720b8794935f1e77bde439564fa421a41f5fed8111aeb7b9ca0ebafb2d/polars-1.27.1-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:4d18a29c65222451818b63cd397b2e95c20412ea0065d735a20a4a79a7b26e8a", size = 32586083, upload-time = "2025-04-11T10:25:32.424Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/1bb108eb278c1eafb303f78c515fb71c9828944eba3fb5c0ac432b9fad28/polars-1.27.1-cp39-abi3-win_amd64.whl", hash = "sha256:a4f832cf478b282d97f8bf86eeae2df66fa1384de1c49bc61f7224a10cc6a5df", size = 35602500, upload-time = "2025-04-11T10:25:35.701Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/5c/cc23daf0a228d6fadbbfc8a8c5165be33157abe5b9d72af3e127e0542857/polars-1.27.1-cp39-abi3-win_arm64.whl", hash = "sha256:4f238ee2e3c5660345cb62c0f731bbd6768362db96c058098359ecffa42c3c6c", size = 31891470, upload-time = "2025-04-11T10:25:38.74Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Relax `polars` from `~=1.26.0` to `>=1.26.0` (tested up to 1.39.3)
- Relax `hydra-core` from `==1.3.2` to `>=1.3.2,<2`
- Relax `meds` from `~=0.4.0` to `>=0.4.0`
- Relax `meds-transforms` from `~=0.5.0` to `>=0.5.0` (tested up to 0.6.3)
- Pin `meds-evaluation` to `==0.0.3` (0.0.4+ removed `validate_binary_classification_schema` API)
- Keep `scipy<1.14.0` as-is (`getnnz()` removed in scipy 1.14)

No code changes - only `pyproject.toml` dependency constraints and `uv.lock` updated.

## Test plan
- [x] All 79 tests pass locally with baseline lockfile resolution
- [x] Tested polars up to 1.39.3 - all pass
- [x] Tested meds-transforms 0.6.3 + polars 1.39.3 - all pass
- [x] Verified scipy 1.14+ breaks `getnnz()` - constraint justified
- [x] Verified meds-evaluation 0.0.4+ breaks `validate_binary_classification_schema` import
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)