### PR TITLE
Fix ReadTheDocs build by pinning mkdocs-autorefs<1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ docs = [
     "mkdocs-section-index==0.3.9",
     "mkdocs-snippets==1.3.0",
     "mkdocstrings==0.25.2",
-    "mkdocstrings-python==1.10.8"
+    "mkdocstrings-python==1.10.8",
+    "mkdocs-autorefs<1.4"
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -2793,6 +2793,7 @@ autogluon = [
 ]
 docs = [
     { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
     { name = "mkdocs-gen-files" },
     { name = "mkdocs-get-deps" },
     { name = "mkdocs-git-authors-plugin" },
@@ -2829,6 +2830,7 @@ requires-dist = [
     { name = "meds-evaluation", specifier = "==0.0.3" },
     { name = "meds-transforms", specifier = ">=0.5.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.0" },
+    { name = "mkdocs-autorefs", marker = "extra == 'docs'", specifier = "<1.4" },
     { name = "mkdocs-gen-files", marker = "extra == 'docs'", specifier = "==0.5.0" },
     { name = "mkdocs-get-deps", marker = "extra == 'docs'", specifier = "==0.2.0" },
     { name = "mkdocs-git-authors-plugin", marker = "extra == 'docs'", specifier = "==0.9.0" },
@@ -2935,16 +2937,16 @@ wheels = [
 
 [[package]]
 name = "mkdocs-autorefs"
-version = "1.4.4"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "markupsafe" },
     { name = "mkdocs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/f4/77e3cf5e7ba54dca168bc718688127844721982ae88b08684669c5b5752d/mkdocs_autorefs-1.3.1.tar.gz", hash = "sha256:a6d30cbcccae336d622a66c2418a3c92a8196b69782774529ad441abb23c0902", size = 2056416, upload-time = "2025-02-11T15:33:29.316Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+    { url = "https://files.pythonhosted.org/packages/db/19/f20edc082c1de2987dbaf30fcc514ed7a908d465a15aba7cba595c3b245a/mkdocs_autorefs-1.3.1-py3-none-any.whl", hash = "sha256:18c504ae4d3ee7f344369bb26cb31d4105569ee252aab7d75ec2734c2c8b0474", size = 2837887, upload-time = "2025-02-11T15:33:25.863Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin `mkdocs-autorefs<1.4` in docs dependencies to fix the RTD build
- `mkdocs-autorefs` 1.4+ expects a proper MkDocs config object with `link_titles`, but `mkdocstrings==0.25.2` registers autorefs with a plain dict, causing `AttributeError: 'dict' object has no attribute 'link_titles'`
- This has been failing on all PRs since mkdocs-autorefs 1.4.0 was released (2025-02-24)

## Test plan
- [ ] RTD build passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)