### PR TITLE
Fix getnnz replacement to correctly count explicit zeros

### DIFF
--- a/src/MEDS_tabular_automl/generate_summarized_reps.py
+++ b/src/MEDS_tabular_automl/generate_summarized_reps.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 import pandas as pd
 import polars as pl
-from scipy.sparse import coo_array, csr_array, sparray
+from scipy.sparse import coo_array, csc_array, csr_array, sparray
 
 from MEDS_tabular_automl.generate_ts_features import get_feature_names
 from MEDS_tabular_automl.utils import (
@@ -38,7 +38,7 @@ def sparse_aggregate(sparse_matrix: sparray, agg: str) -> np.ndarray | coo_array
     elif agg == "sum_sqd":
         merged_matrix = sparse_matrix.power(2).sum(axis=0, dtype=sparse_matrix.dtype)
     elif agg == "count":
-        merged_matrix = (sparse_matrix != 0).sum(axis=0)
+        merged_matrix = np.diff(csc_array(sparse_matrix).indptr)
     else:
         raise ValueError(f"Aggregation method '{agg}' not implemented.")
     return merged_matrix


### PR DESCRIPTION
## Summary

Fixes a correctness regression introduced in #161 where `getnnz(axis=0)` was replaced with `(sparse_matrix != 0).sum(axis=0)`.

The `(!=0).sum` approach only counts **numerically nonzero** entries, but `getnnz` counted all **stored entries** including explicit zeros. In this codebase, value-based time-series features can legitimately have `numeric_value == 0.0` (e.g., zero blood pressure change), which gets stored as an explicit zero in the sparse matrix. The "count" aggregation should count these as "observed", not skip them.

**Fix**: Use `np.diff(csc_array(sparse_matrix).indptr)` which counts stored entries per column, matching the original `getnnz(axis=0)` semantics.

Found during review of #162.

## Test plan
- [x] All 79 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)